### PR TITLE
データ取得処理の改善と実行スケジュールの変更

### DIFF
--- a/backend/cron_job.sh
+++ b/backend/cron_job.sh
@@ -9,6 +9,6 @@ echo "$(date): Starting data fetch..." >> $LOG_DIR/cron.log
 
 # Pythonスクリプトを実行
 cd /app/backend
-python data_fetcher.py >> $LOG_DIR/fetch.log 2>&1
+python data_fetcher.py fetch >> $LOG_DIR/fetch.log 2>&1
 
 echo "$(date): Data fetch completed" >> $LOG_DIR/cron.log

--- a/backend/cron_job_generate.sh
+++ b/backend/cron_job_generate.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# ログディレクトリ
+LOG_DIR="/app/logs"
+mkdir -p $LOG_DIR
+
+# 現在時刻をログ
+echo "$(date): Starting report generation..." >> $LOG_DIR/cron.log
+
+# Pythonスクリプトを実行
+cd /app/backend
+python data_fetcher.py generate >> $LOG_DIR/generate.log 2>&1
+
+echo "$(date): Report generation completed" >> $LOG_DIR/cron.log

--- a/crontab
+++ b/crontab
@@ -1,4 +1,4 @@
-# 米国市場クローズ後のデータ取得
-0 7 * * 2-6 /app/backend/cron_job.sh >> /app/logs/cron.log 2>&1
-# 週次レポート更新（月曜日朝7時）
-0 7 * * 1 /app/backend/cron_job.sh >> /app/logs/cron.log 2>&1
+# 6:30にデータを取得
+30 6 * * 1-6 /app/backend/cron_job.sh >> /app/logs/cron.log 2>&1
+# 7:00にレポートを生成
+0 7 * * 1-6 /app/backend/cron_job_generate.sh >> /app/logs/cron.log 2>&1


### PR DESCRIPTION
yfinanceを利用したデータ取得処理を改善し、cronによる実行スケジュールをユーザーの要求に合わせて変更しました。

主な変更点：
- 1時間足から4時間足へのデータ変換ロジックを、手動のループ処理からPandasの`resample`メソッドを使用するようにリファクタリングし、処理の堅牢性を向上させました。
- データ取得プロセスを2段階に分割しました。
  1. `fetch`モード（6:30実行）：yfinanceなどから主要な市場データを取得し、一時ファイルに保存します。
  2. `generate`モード（7:00実行）：一時ファイルを読み込み、AIによる解説生成やスクリーンショット取得などの時間のかかる処理を実行し、最終的なデータファイルを生成してWebに反映させます。
- 上記の変更に伴い、`data_fetcher.py`にコマンドライン引数（`fetch`/`generate`）を導入し、`crontab`と関連するシェルスクリプトを更新しました。